### PR TITLE
fix: correct 2 typos in footer.svelte

### DIFF
--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -7,8 +7,8 @@
     >. Hail yourself.
   </h5>
   <i class="text-sm"
-    >This website is not owned, operated, or even acknowledge by LPN or any of
-    its affillates. Links are valid only in the US region of various streaming
+    >This website is not owned, operated, or even acknowledged by LPN or any of
+    its affiliates. Links are valid only in the US region of various streaming
     sites. This website does not aim to make money through affiliate links or
     sign-up referrals or any such shenanigans and is only for informational
     purposes. If you like what I did here and wanna help out or buy me a beer,


### PR DESCRIPTION
## Summary

Fix 2 typos in src/components/footer.svelte:

- `acknowledge` → `acknowledged`
- `affillates` → `affiliates`

## Testing

N/A - documentation only change.

## Related Issue

Fixes #9